### PR TITLE
feat: add expiration TTLs to state library

### DIFF
--- a/state.js
+++ b/state.js
@@ -18,6 +18,7 @@ export class State extends EventTarget {
     }
 
     this.stateMap = new Map()
+    this.ttlMap = new Map()
 
     this.loadState()
 
@@ -30,18 +31,46 @@ export class State extends EventTarget {
           // console.log("storage event", e)
           let key = e.key.substring(State.statePrefix.length)
           let value = null
+          let expiresAt = null
           if (e.newValue) {
-            value = JSON.parse(e.newValue)
+            try {
+              const parsed = JSON.parse(e.newValue)
+              value = parsed.value
+              expiresAt = parsed.expiresAt
+            } catch (err) {
+              console.log(`[state] ${e.key} invalid json`)
+            }
           }
-          this.dispatchEvent(
-            new CustomEvent(key, {
-              detail: {
-                action: value ? 'set' : 'delete',
-                key,
-                value,
-              },
-            }),
-          )
+
+          if (e.newValue && (!expiresAt || Date.now() <= expiresAt)) {
+            this.stateMap.set(key, value)
+            if (expiresAt) {
+              this.ttlMap.set(key, expiresAt)
+            } else {
+              this.ttlMap.delete(key)
+            }
+            this.dispatchEvent(
+              new CustomEvent(key, {
+                detail: {
+                  action: value ? 'set' : 'delete',
+                  key,
+                  value,
+                },
+              }),
+            )
+          } else {
+            const r = this.stateMap.delete(key)
+            this.ttlMap.delete(key)
+            this.dispatchEvent(
+              new CustomEvent(key, {
+                detail: {
+                  action: 'delete',
+                  key,
+                  deleted: r,
+                },
+              }),
+            )
+          }
         }
       })
     }
@@ -51,10 +80,18 @@ export class State extends EventTarget {
     if (!this.storageObj) return
     for (const key in this.storageObj) {
       if (key.startsWith(State.statePrefix)) {
-        let value = this.storageObj.getItem(key)
+        let raw = this.storageObj.getItem(key)
         try {
-          value = JSON.parse(value)
-          this.stateMap.set(key.substring(State.statePrefix.length), value)
+          const { value, expiresAt } = JSON.parse(raw)
+          const stateKey = key.substring(State.statePrefix.length)
+          if (expiresAt && Date.now() > expiresAt) {
+            this.storageObj.removeItem(key)
+          } else {
+            this.stateMap.set(stateKey, value)
+            if (expiresAt) {
+              this.ttlMap.set(stateKey, expiresAt)
+            }
+          }
         } catch (e) {
           console.log(`[state] ${key} invalid json`)
         }
@@ -68,11 +105,20 @@ export class State extends EventTarget {
    * @param {any} value
    * @param {object} opts
    * @param {boolean} [opts.skipStorage=false] if true, the value will not be stored in storage
+   * @param {number} [opts.ttl] Time-To-Live in milliseconds
    */
   set(key, value, opts = {}) {
+    const expiresAt = opts.ttl ? Date.now() + opts.ttl : null
     const m = this.stateMap.set(key, value)
+    if (expiresAt) {
+      this.ttlMap.set(key, expiresAt)
+    } else {
+      this.ttlMap.delete(key)
+    }
+
     if (!opts.skipStorage && this.storageObj) {
-      this.storageObj.setItem(`${State.statePrefix}${key}`, JSON.stringify(value))
+      const wrapped = { value, expiresAt }
+      this.storageObj.setItem(`${State.statePrefix}${key}`, JSON.stringify(wrapped))
     }
     this.dispatchEvent(
       new CustomEvent(key, {
@@ -88,6 +134,7 @@ export class State extends EventTarget {
 
   delete(key) {
     const r = this.stateMap.delete(key)
+    this.ttlMap.delete(key)
     if (this.storageObj) {
       this.storageObj.removeItem(`${State.statePrefix}${key}`)
     }
@@ -103,6 +150,11 @@ export class State extends EventTarget {
   }
 
   get(key) {
+    const expiresAt = this.ttlMap.get(key)
+    if (expiresAt && Date.now() > expiresAt) {
+      this.delete(key)
+      return undefined
+    }
     return this.stateMap.get(key)
   }
 }

--- a/state.js
+++ b/state.js
@@ -35,8 +35,8 @@ export class State extends EventTarget {
           if (e.newValue) {
             try {
               const parsed = JSON.parse(e.newValue)
-              value = parsed.value
-              expiresAt = parsed.expiresAt
+              value = parsed?.value
+              expiresAt = parsed?.expiresAt
             } catch (err) {
               console.log(`[state] ${e.key} invalid json`)
             }
@@ -66,6 +66,7 @@ export class State extends EventTarget {
                 detail: {
                   action: 'delete',
                   key,
+                  value: null,
                   deleted: r,
                 },
               }),
@@ -82,7 +83,9 @@ export class State extends EventTarget {
       if (key.startsWith(State.statePrefix)) {
         let raw = this.storageObj.getItem(key)
         try {
-          const { value, expiresAt } = JSON.parse(raw)
+          const parsed = JSON.parse(raw)
+          const value = parsed?.value
+          const expiresAt = parsed?.expiresAt
           const stateKey = key.substring(State.statePrefix.length)
           if (expiresAt && Date.now() > expiresAt) {
             this.storageObj.removeItem(key)


### PR DESCRIPTION
This PR adds expiration TTL (Time-To-Live) support to the state library.

Key changes:
- Wraps all stored values in a \{ value, expiresAt }\ object to track expiration.
- Performs lazy cleanup of expired values on \get()\, during initialization (\loadState()\), and within the cross-tab \storage\ event listener.
- Retains compatibility with the standard Map/EventTarget APIs (i.e. \get(key)\ returns the raw unwrapped value).